### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/update-flake.yml
+++ b/.github/workflows/update-flake.yml
@@ -6,6 +6,10 @@ on:
     - cron: '0 6 * * 5'
   workflow_dispatch: {}
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   update-flake-lock:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/mads256h/nix-config/security/code-scanning/3](https://github.com/mads256h/nix-config/security/code-scanning/3)

Add an explicit `permissions` block to the workflow so token scopes are constrained and documented.  
Best fix here: set workflow-level permissions to the minimum needed for the shown steps:

- `contents: write` (needed to push branch/commit for PR creation workflows)
- `pull-requests: write` (needed to open/update PR metadata)

Apply this near the top-level workflow keys (after `on:` and before `jobs:`), so it applies consistently to all jobs unless overridden. No imports, methods, or dependencies are needed—only YAML edits in `.github/workflows/update-flake.yml`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
