### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "master" ]
 
+permissions:
+  contents: read
+
 jobs:
   vm-boot-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/mads256h/nix-config/security/code-scanning/2](https://github.com/mads256h/nix-config/security/code-scanning/2)

Add an explicit workflow-level `permissions` block in `.github/workflows/build.yml` so all jobs inherit a minimal token scope by default.

Best fix (without changing functionality): insert

```yml
permissions:
  contents: read
```

near the top level (after `on:` block and before `jobs:`). This is the minimal recommended setting from CodeQL and is appropriate for workflows that primarily check out code and build. If a specific job later needs extra scopes, it can override with job-level `permissions`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
