### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "master" ]
 
+permissions:
+  contents: read
+
 jobs:
   vm-boot-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/mads256h/nix-config/security/code-scanning/1](https://github.com/mads256h/nix-config/security/code-scanning/1)

Add an explicit top-level `permissions` block in `.github/workflows/build.yml` so it applies to all jobs unless overridden. The minimal safe setting here is:

- `contents: read`

This preserves existing functionality (checkout/read access for source) while preventing unnecessary write scopes on `GITHUB_TOKEN`. The best single change is to insert the `permissions` block after the `on:` triggers and before `jobs:`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
